### PR TITLE
[6주차] 이경준/[feat] USER API 연동

### DIFF
--- a/src/api/auth/authTypes.ts
+++ b/src/api/auth/authTypes.ts
@@ -1,5 +1,4 @@
 // 공통
-
 export interface TokenPair {
   accessToken: string;
   refreshToken: string;
@@ -18,7 +17,6 @@ export interface BaseUserInfo {
 type BasicProfile = Pick<BaseUserInfo, 'nickname' | 'profilePicture' | 'introduction'>;
 
 // 로그인
-
 export interface LoginRequest {
   email: string;
   password: string;
@@ -30,7 +28,6 @@ export interface LoginData extends TokenPair, BasicProfile {
 }
 
 // 회원가입
-
 export type RegisterRequest = BaseUserInfo & {
   password: string;
 };
@@ -38,7 +35,6 @@ export type RegisterRequest = BaseUserInfo & {
 export type RegisterData = Pick<BaseUserInfo, 'email' | 'nickname' | 'profilePicture' | 'introduction'>;
 
 // OAuth 회원가입
-
 export type RegisterOAuthRequest = BaseUserInfo & {
   kakaoId: number;
 };

--- a/src/api/image/imageApi.ts
+++ b/src/api/image/imageApi.ts
@@ -1,0 +1,22 @@
+import { axiosInstance } from '../apiInstance';
+import type { ApiResponse } from '../apiTypes';
+import type * as ImageTypes from './imageTypes';
+
+// Presigned URL 가져오기
+export const getPresignedUrl = async (fileName: string): Promise<ApiResponse<ImageTypes.PresignedUrlData>> => {
+  const response = await axiosInstance.get<ApiResponse<ImageTypes.PresignedUrlData>>('/images/presigned-url', {
+    params: { fileName },
+  });
+  return response.data;
+};
+
+// S3에 이미지 업로드
+export const uploadImageToS3 = async (presignedUrl: string, file: File): Promise<void> => {
+  await fetch(presignedUrl, {
+    method: 'PUT',
+    body: file,
+    headers: {
+      'Content-Type': file.type,
+    },
+  });
+};

--- a/src/api/image/imageApi.ts
+++ b/src/api/image/imageApi.ts
@@ -2,7 +2,7 @@ import { axiosInstance } from '../apiInstance';
 import type { ApiResponse } from '../apiTypes';
 import type * as ImageTypes from './imageTypes';
 
-// Presigned URL 가져오기
+// Presigned URL
 export const getPresignedUrl = async (fileName: string): Promise<ApiResponse<ImageTypes.PresignedUrlData>> => {
   const response = await axiosInstance.get<ApiResponse<ImageTypes.PresignedUrlData>>('/images/presigned-url', {
     params: { fileName },
@@ -12,11 +12,24 @@ export const getPresignedUrl = async (fileName: string): Promise<ApiResponse<Ima
 
 // S3에 이미지 업로드
 export const uploadImageToS3 = async (presignedUrl: string, file: File): Promise<void> => {
-  await fetch(presignedUrl, {
+  const response = await fetch(presignedUrl, {
     method: 'PUT',
     body: file,
     headers: {
       'Content-Type': file.type,
     },
   });
+
+  if (!response.ok) {
+    throw new Error(`S3 upload failed: ${response.status}`);
+  }
+};
+
+// 이미지 업로드 커스텀 훅
+export const uploadImage = async (file: File): Promise<ImageTypes.UploadImageResult> => {
+  const response = await getPresignedUrl(file.name);
+  const presignedUrl = response.data;
+  await uploadImageToS3(presignedUrl, file);
+  const imageUrl = presignedUrl.split('?')[0];
+  return { imageUrl };
 };

--- a/src/api/image/imageQuery.ts
+++ b/src/api/image/imageQuery.ts
@@ -1,15 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
-import { getPresignedUrl, uploadImageToS3 } from './imageApi';
+import { uploadImage } from './imageApi';
 import type { UploadImageParams, UploadImageResult } from './imageTypes';
 
 export const useUploadImageMutation = () => {
   return useMutation<UploadImageResult, Error, UploadImageParams>({
-    mutationFn: async ({ file }) => {
-      const response = await getPresignedUrl(file.name);
-      const presignedUrl = response.data;
-      await uploadImageToS3(presignedUrl, file);
-      const imageUrl = presignedUrl.split('?')[0];
-      return { imageUrl };
-    },
+    mutationFn: ({ file }) => uploadImage(file),
   });
 };

--- a/src/api/image/imageQuery.ts
+++ b/src/api/image/imageQuery.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+import { getPresignedUrl, uploadImageToS3 } from './imageApi';
+import type { UploadImageParams, UploadImageResult } from './imageTypes';
+
+export const useUploadImageMutation = () => {
+  return useMutation<UploadImageResult, Error, UploadImageParams>({
+    mutationFn: async ({ file }) => {
+      const response = await getPresignedUrl(file.name);
+      const presignedUrl = response.data;
+      await uploadImageToS3(presignedUrl, file);
+      const imageUrl = presignedUrl.split('?')[0];
+      return { imageUrl };
+    },
+  });
+};

--- a/src/api/image/imageTypes.ts
+++ b/src/api/image/imageTypes.ts
@@ -1,0 +1,13 @@
+export interface GetPresignedUrlRequest {
+  fileName: string;
+}
+
+export type PresignedUrlData = string;
+
+export interface UploadImageParams {
+  file: File;
+}
+
+export interface UploadImageResult {
+  imageUrl: string;
+}

--- a/src/api/user/userApi.ts
+++ b/src/api/user/userApi.ts
@@ -22,14 +22,6 @@ export const updateProfilePicture = async (
   return response.data;
 };
 
-// 비밀번호 수정
-export const updatePassword = async (
-  data: UserTypes.UpdatePasswordRequest
-): Promise<ApiResponse<UserTypes.UpdatePasswordData>> => {
-  const response = await axiosInstance.patch<ApiResponse<UserTypes.UpdatePasswordData>>('/users/password', data);
-  return response.data;
-};
-
 // 닉네임 수정
 export const updateNickname = async (
   data: UserTypes.UpdateNicknameRequest

--- a/src/api/user/userApi.ts
+++ b/src/api/user/userApi.ts
@@ -1,8 +1,39 @@
 import { axiosInstance } from '../apiInstance';
-import type { UserResponse } from './userTypes';
+import type { ApiResponse } from '../apiTypes';
+import type * as UserTypes from './userTypes';
 
 // 유저 정보 조회
-export const getUserInfo = async (): Promise<UserResponse> => {
-  const response = await axiosInstance.get<UserResponse>('/users/me');
+export const getUserInfo = async (): Promise<ApiResponse<UserTypes.UserData>> => {
+  const response = await axiosInstance.get<ApiResponse<UserTypes.UserData>>('/users/me');
+  return response.data;
+};
+
+// 유저 정보 수정
+export const updateUser = async (data: UserTypes.UpdateUserRequest): Promise<ApiResponse<UserTypes.UpdateUserData>> => {
+  const response = await axiosInstance.patch<ApiResponse<UserTypes.UpdateUserData>>('/users', data);
+  return response.data;
+};
+
+// 프로필 사진 수정
+export const updateProfilePicture = async (
+  data: UserTypes.UpdateProfilePictureRequest
+): Promise<ApiResponse<UserTypes.UpdateProfilePictureData>> => {
+  const response = await axiosInstance.patch<ApiResponse<UserTypes.UpdateProfilePictureData>>('/users/picture', data);
+  return response.data;
+};
+
+// 비밀번호 수정
+export const updatePassword = async (
+  data: UserTypes.UpdatePasswordRequest
+): Promise<ApiResponse<UserTypes.UpdatePasswordData>> => {
+  const response = await axiosInstance.patch<ApiResponse<UserTypes.UpdatePasswordData>>('/users/password', data);
+  return response.data;
+};
+
+// 닉네임 수정
+export const updateNickname = async (
+  data: UserTypes.UpdateNicknameRequest
+): Promise<ApiResponse<UserTypes.UpdateNicknameData>> => {
+  const response = await axiosInstance.patch<ApiResponse<UserTypes.UpdateNicknameData>>('/users/nickname', data);
   return response.data;
 };

--- a/src/api/user/userQuery.ts
+++ b/src/api/user/userQuery.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
-import { getUserInfo, updateUser, updateProfilePicture, updatePassword, updateNickname } from './userApi';
+import { getUserInfo, updateUser, updateProfilePicture, updateNickname } from './userApi';
 import { useAuthStore } from '@/stores/useAuthStore';
 import type { ApiResponse } from '../apiTypes';
 import type * as UserTypes from './userTypes';
@@ -62,13 +62,6 @@ export const useUpdateProfilePicture = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['userInfo'] });
     },
-  });
-};
-
-// 비밀번호 수정
-export const useUpdatePassword = () => {
-  return useMutation({
-    mutationFn: updatePassword,
   });
 };
 

--- a/src/api/user/userQuery.ts
+++ b/src/api/user/userQuery.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
-import { getUserInfo } from './userApi';
+import { getUserInfo, updateUser, updateProfilePicture, updatePassword, updateNickname } from './userApi';
 import { useAuthStore } from '@/stores/useAuthStore';
 import type { ApiResponse } from '../apiTypes';
 import type * as UserTypes from './userTypes';
@@ -39,4 +39,47 @@ export const useAuth = () => {
     isLoading,
     error,
   };
+};
+
+// 유저 정보 수정
+export const useUpdateUser = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateUser,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['userInfo'] });
+    },
+  });
+};
+
+// 프로필 사진 수정
+export const useUpdateProfilePicture = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateProfilePicture,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['userInfo'] });
+    },
+  });
+};
+
+// 비밀번호 수정
+export const useUpdatePassword = () => {
+  return useMutation({
+    mutationFn: updatePassword,
+  });
+};
+
+// 닉네임 수정
+export const useUpdateNickname = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateNickname,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['userInfo'] });
+    },
+  });
 };

--- a/src/api/user/userTypes.ts
+++ b/src/api/user/userTypes.ts
@@ -1,6 +1,4 @@
-import type { ApiResponse } from '../apiTypes';
-
-// 사용자 정보
+// 공통 사용자 정보
 export interface UserData {
   id: number;
   email: string;
@@ -11,4 +9,26 @@ export interface UserData {
   introduction: string;
 }
 
-export type UserResponse = ApiResponse<UserData>;
+// 유저 정보 수정
+export type UpdateUserRequest = Omit<UserData, 'id'> & {
+  password: string;
+};
+
+export type UpdateUserData = Record<string, never>;
+
+// 프로필 사진 수정
+export type UpdateProfilePictureRequest = Pick<UserData, 'profilePicture'>;
+
+export type UpdateProfilePictureData = Record<string, never>;
+
+// 비밀번호 수정
+export interface UpdatePasswordRequest {
+  password: string;
+}
+
+export type UpdatePasswordData = Record<string, never>;
+
+// 닉네임 수정
+export type UpdateNicknameRequest = Pick<UserData, 'nickname'>;
+
+export type UpdateNicknameData = Record<string, never>;

--- a/src/api/user/userTypes.ts
+++ b/src/api/user/userTypes.ts
@@ -10,9 +10,7 @@ export interface UserData {
 }
 
 // 유저 정보 수정
-export type UpdateUserRequest = Omit<UserData, 'id'> & {
-  password: string;
-};
+export type UpdateUserRequest = Omit<UserData, 'id'>;
 
 export type UpdateUserData = Record<string, never>;
 

--- a/src/api/user/userTypes.ts
+++ b/src/api/user/userTypes.ts
@@ -19,11 +19,6 @@ export type UpdateProfilePictureRequest = Pick<UserData, 'profilePicture'>;
 
 export type UpdateProfilePictureData = Record<string, never>;
 
-// 비밀번호 수정
-export interface UpdatePasswordRequest {
-  password: string;
-}
-
 export type UpdatePasswordData = Record<string, never>;
 
 // 닉네임 수정

--- a/src/components/common/PageHeader/PageHeader.tsx
+++ b/src/components/common/PageHeader/PageHeader.tsx
@@ -1,11 +1,11 @@
 import { PageHeaderLeft, PageHeaderRight } from '@/components';
 import { PageHeaderProps } from '@/types/pageheader';
 
-const PageHeader = ({ className = '', type, onHamburgerClick, onEdit, onCancel, onSave, isOwner }: PageHeaderProps) => {
+const PageHeader = ({ className = '', type, onHamburgerClick, onEdit, onCancel, isOwner }: PageHeaderProps) => {
   return (
     <header className={`page-header-container ${className}`}>
       <PageHeaderLeft onHamburgerClick={onHamburgerClick} />
-      <PageHeaderRight type={type} onEdit={onEdit} onCancel={onCancel} onSave={onSave} isOwner={isOwner} />
+      <PageHeaderRight type={type} onEdit={onEdit} onCancel={onCancel} isOwner={isOwner} />
     </header>
   );
 };

--- a/src/components/common/PageHeader/PageHeaderRight.tsx
+++ b/src/components/common/PageHeader/PageHeaderRight.tsx
@@ -1,8 +1,8 @@
-import { PageHeaderRenderers } from '@/components/common/Pageheader/PageHeaderRightRenderers';
+import { PageHeaderRenderers } from '@/components/common/PageHeader/PageHeaderRightRenderers';
 import { PageHeaderRightProps } from '@/types/pageheader';
 
-const PageHeaderRight = ({ type, onEdit, onCancel, onSave, isOwner }: PageHeaderRightProps) => {
-  return PageHeaderRenderers[type]({ onEdit, onCancel, onSave, isOwner });
+const PageHeaderRight = ({ type, onEdit, onCancel, isOwner }: PageHeaderRightProps) => {
+  return PageHeaderRenderers[type]({ onEdit, onCancel, isOwner });
 };
 
 export default PageHeaderRight;

--- a/src/components/common/PageHeader/RightRenders/EditProfileTypeHeader.tsx
+++ b/src/components/common/PageHeader/RightRenders/EditProfileTypeHeader.tsx
@@ -4,10 +4,9 @@ import { PAGEHEADER_TEXTS } from '@/constants';
 interface EditProfileTypeHeaderProps {
   onEdit?: () => void;
   onCancel?: () => void;
-  onSave?: () => void;
 }
 
-export const EditProfileTypeHeader = ({ onEdit, onCancel, onSave }: EditProfileTypeHeaderProps) => {
+export const EditProfileTypeHeader = ({ onEdit, onCancel }: EditProfileTypeHeaderProps) => {
   const isEditMode = useEditModeStore(state => state.isEditMode);
 
   if (!isEditMode) {
@@ -23,7 +22,7 @@ export const EditProfileTypeHeader = ({ onEdit, onCancel, onSave }: EditProfileT
       <button type="button" onClick={onCancel} className="flex items-center justify-center gap-1 px-3 py-2">
         <span className="text-sm font-regular text-warning">{PAGEHEADER_TEXTS.EDIT_PROFILE.CANCEL_BUTTON}</span>
       </button>
-      <button type="submit" onClick={onSave} className="flex items-center justify-center gap-1 px-3 py-2">
+      <button type="submit" form="edit-profile-form" className="flex items-center justify-center gap-1 px-3 py-2">
         <span className="text-sm font-regular text-black">{PAGEHEADER_TEXTS.EDIT_PROFILE.SAVE_BUTTON}</span>
       </button>
     </div>

--- a/src/components/common/Text/TextFieldVariants.ts
+++ b/src/components/common/Text/TextFieldVariants.ts
@@ -14,7 +14,7 @@ export const textFieldVariants = tv({
       filled: 'bg-gray-90',
     },
     disabled: {
-      true: 'opacity-50 cursor-not-allowed',
+      true: 'opacity-100 cursor-not-allowed',
       false: '',
     },
     fullWidth: {

--- a/src/components/mypage/EditProfileForm.tsx
+++ b/src/components/mypage/EditProfileForm.tsx
@@ -6,30 +6,43 @@ import { cn } from '@/utils/cn';
 import { Spacer, Textarea } from '@/components';
 import * as UserQuery from '@/api/user/userQuery';
 import { useEditModeStore } from '@/stores/useEditModeStore';
+import { useAuthStore } from '@/stores/useAuthStore';
 import { useEditProfile } from '@/hooks';
-import { SIGNUP_FORM_FIELDS } from '@/constants';
+import { SIGNUP_FORM_FIELDS, MYPAGE_TEXTS } from '@/constants';
 import { signupSchema, SignupFormData } from '@/utils/schemas';
 import { EditProfileFormProps } from '@/types/mypage';
+import KakaoIcon from '@/assets/icons/common/kakao.svg?react';
 
 const STYLES = {
   container: 'flex flex-col items-center self-stretch',
   spacer: 'w-full max-w-content',
   textareaCommon: 'w-full max-w-content px-0',
+  kakaoEmailField: 'flex w-full max-w-content flex-col items-start gap-2 py-3 px-4',
+  kakaoEmailTitle: 'text-sm font-light text-gray-56',
+  kakaoEmailBox:
+    'flex w-full items-center gap-2 rounded px-4 py-3 border border-gray-90 bg-gray-90 text-sm text-gray-56',
 } as const;
 
 const DISABLED_FIELDS = ['email', 'name'];
 const EXCLUDED_FIELDS = ['nickname', 'introduction'];
 
+const getExcludedFields = (isKakaoUser: boolean) => {
+  return isKakaoUser ? [...EXCLUDED_FIELDS, 'password', 'passwordConfirm'] : EXCLUDED_FIELDS;
+};
+
 const EditProfileForm = ({ className }: EditProfileFormProps) => {
   const { user } = UserQuery.useAuth();
   const { isEditMode, setEditMode } = useEditModeStore();
+  const isKakaoUser = useAuthStore(state => state.isKakaoUser);
   const { headerNickname, headerIntroduction } = useOutletContext<{
     headerNickname: string;
     headerIntroduction: string;
   }>();
 
+  const excludedFields = getExcludedFields(isKakaoUser);
+
+  // 컴포넌트 unmount 시 편집 모드 종료
   useEffect(() => {
-    // 초기화
     return () => {
       setEditMode(false);
     };
@@ -80,7 +93,6 @@ const EditProfileForm = ({ className }: EditProfileFormProps) => {
   }, [isEditMode, user, reset]);
 
   const onSubmit = (data: SignupFormData) => {
-    // MyPageHeader에서 입력한 nickname과 introduction을 병합
     const mergedData = {
       ...data,
       nickname: headerNickname,
@@ -93,7 +105,17 @@ const EditProfileForm = ({ className }: EditProfileFormProps) => {
     <form id="edit-profile-form" onSubmit={handleSubmit(onSubmit)} className={cn(STYLES.container, className)}>
       <Spacer height="md" className={STYLES.spacer} />
 
-      {SIGNUP_FORM_FIELDS.filter(field => !EXCLUDED_FIELDS.includes(field.name)).map(field => {
+      {isKakaoUser && (
+        <div className={STYLES.kakaoEmailField}>
+          <span className={STYLES.kakaoEmailTitle}>{MYPAGE_TEXTS.LABELS.SOCIAL_LOGIN}</span>
+          <div className={STYLES.kakaoEmailBox}>
+            <KakaoIcon width={18} height={18} />
+            {MYPAGE_TEXTS.LABELS.KAKAO_LOGIN}
+          </div>
+        </div>
+      )}
+
+      {SIGNUP_FORM_FIELDS.filter(field => !excludedFields.includes(field.name)).map(field => {
         const isDisabled = isFieldDisabled(field.name);
         const isAlwaysDisabled = DISABLED_FIELDS.includes(field.name);
         const isPasswordField = field.name === 'password' || field.name === 'passwordConfirm';

--- a/src/components/mypage/EditProfileForm.tsx
+++ b/src/components/mypage/EditProfileForm.tsx
@@ -26,6 +26,10 @@ const STYLES = {
 const DISABLED_FIELDS = ['email', 'name'];
 const EXCLUDED_FIELDS = ['nickname', 'introduction'];
 
+// 백엔드 API 수정 후 제거 필요
+// 현재 카카오 유저는 introduction 필드를 헤더에서만 표시하고 폼에서는 제외
+// 이유: /users API의 password가 required여서 introduction 변경 시 password 필요
+// 백엔드 수정 후: getExcludedFields 함수 제거하고 EXCLUDED_FIELDS만 사용
 const getExcludedFields = (isKakaoUser: boolean) => {
   return isKakaoUser ? [...EXCLUDED_FIELDS, 'password', 'passwordConfirm'] : EXCLUDED_FIELDS;
 };
@@ -62,7 +66,10 @@ const EditProfileForm = ({ className }: EditProfileFormProps) => {
     formState: { errors },
     reset,
   } = useForm<SignupFormData>({
-    resolver: zodResolver(signupSchema),
+    // 백엔드 API 수정 후 수정 필요
+    // 현재 카카오 유저는 validation 제외 (password 필드가 없어서 signupSchema 통과 불가)
+    // 백엔드 수정 후: 카카오 유저용 별도 schema 생성 또는 조건부 validation 적용
+    resolver: isKakaoUser ? undefined : zodResolver(signupSchema),
     mode: 'onChange',
     defaultValues: {
       email: user?.email || '',

--- a/src/components/mypage/MyPageHeader.tsx
+++ b/src/components/mypage/MyPageHeader.tsx
@@ -4,7 +4,6 @@ import { MYPAGE_TEXTS } from '@/constants';
 import { SettingsIcon, EditProfileIcon } from '@/assets/icons';
 import profileImage from '@/assets/profile.png';
 import { MyPageHeaderProps } from '@/types/mypage';
-import { useEditProfile } from '@/hooks';
 
 const STYLES = {
   profileContent: 'flex flex-col w-full max-w-content py-3 px-4 items-start gap-2.5',
@@ -21,15 +20,23 @@ const MyPageHeader = ({
   isEditMode,
   nickname,
   bio,
+  profilePicture,
   onNicknameChange,
   onBioChange,
   onEditClick,
   showSettingsButton = true,
   isEditProfilePage = false,
+  previewImage: previewImageProp,
+  fileInputRef: fileInputRefProp,
+  handleImageUpload: handleImageUploadProp,
+  handleProfileImageClick: handleProfileImageClickProp,
+  validateField: validateFieldProp,
 }: MyPageHeaderProps) => {
-  const { previewImage, fileInputRef, handleImageUpload, handleProfileImageClick, validateField } = useEditProfile({
-    defaultProfileImage: profileImage,
-  });
+  const previewImage = previewImageProp || profilePicture || profileImage;
+  const fileInputRef = fileInputRefProp || { current: null };
+  const handleImageUpload = handleImageUploadProp || (() => {});
+  const handleProfileImageClick = handleProfileImageClickProp || (() => {});
+  const validateField = validateFieldProp || (() => undefined);
 
   const [nicknameError, setNicknameError] = useState<string | undefined>();
   const [bioError, setBioError] = useState<string | undefined>();

--- a/src/components/mypage/MyPageHeader.tsx
+++ b/src/components/mypage/MyPageHeader.tsx
@@ -7,9 +7,9 @@ import { useEditProfile } from '@/hooks';
 
 const STYLES = {
   profileContent: 'flex flex-col w-full max-w-content py-3 px-4 items-start gap-2.5',
-  profileImageWrapper: 'relative flex w-16 h-16 items-center gap-2.5 aspect-square rounded-full overflow-hidden',
-  profileImage: 'w-full h-full object-cover',
-  profileEditIcon: 'absolute right-0 bottom-0 w-6 h-6 flex-shrink-0',
+  profileImageWrapper: 'relative flex w-16 h-16 items-center gap-2.5 aspect-square',
+  profileImage: 'w-full h-full object-cover rounded-full',
+  profileEditIcon: 'absolute right-0 bottom-0 w-6 h-6 flex-shrink-0 z-10',
   profileEditFields: 'flex flex-col w-full max-w-content px-4 items-start',
   textFieldDivider: 'flex px-1.5 justify-center items-center gap-2.5 self-stretch mt-1',
   hintText: 'flex-1 text-gray-78 font-light text-xs leading-[160%]',
@@ -20,23 +20,13 @@ const MyPageHeader = ({
   isEditMode,
   nickname,
   bio,
+  onNicknameChange,
+  onBioChange,
   onEditClick,
   showSettingsButton = true,
   isEditProfilePage = false,
 }: MyPageHeaderProps) => {
-  const {
-    register,
-    errors,
-    watchedNickname,
-    watchedBio,
-    previewImage,
-    fileInputRef,
-    handleImageUpload,
-    handleProfileImageClick,
-  } = useEditProfile({
-    nickname,
-    bio,
-    isEditMode,
+  const { previewImage, fileInputRef, handleImageUpload, handleProfileImageClick } = useEditProfile({
     defaultProfileImage: profileImage,
   });
 
@@ -64,30 +54,26 @@ const MyPageHeader = ({
       {isEditProfilePage ? (
         <div className={STYLES.profileEditFields}>
           <TextField
-            {...register('nickname')}
-            value={watchedNickname}
+            value={nickname}
+            onChange={e => onNicknameChange?.(e.target.value)}
             placeholder={MYPAGE_TEXTS.PROFILE.NICKNAME_PLACEHOLDER}
             fullWidth
             fontSize="medium"
             textColor="title"
             disabled={!isEditMode}
-            error={Boolean(errors.nickname?.message)}
-            errorMessage={errors.nickname?.message}
           />
           <div className={STYLES.textFieldDivider}>
             <span className={STYLES.hintText}>{MYPAGE_TEXTS.PROFILE.NICKNAME_HINT}</span>
           </div>
           <TextField
-            {...register('bio')}
-            value={watchedBio}
+            value={bio}
+            onChange={e => onBioChange?.(e.target.value)}
             placeholder={MYPAGE_TEXTS.PROFILE.BIO_PLACEHOLDER}
             fullWidth
             fontSize="light"
             textColor="gray78"
             className="mb-3 mt-3"
             disabled={!isEditMode}
-            error={Boolean(errors.bio?.message)}
-            errorMessage={errors.bio?.message}
           />
         </div>
       ) : (

--- a/src/components/mypage/MyPageHeader.tsx
+++ b/src/components/mypage/MyPageHeader.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { PostHeader, TextBox, TextField } from '@/components';
 import { MYPAGE_TEXTS } from '@/constants';
 import { SettingsIcon, EditProfileIcon } from '@/assets/icons';
@@ -26,9 +27,31 @@ const MyPageHeader = ({
   showSettingsButton = true,
   isEditProfilePage = false,
 }: MyPageHeaderProps) => {
-  const { previewImage, fileInputRef, handleImageUpload, handleProfileImageClick } = useEditProfile({
+  const { previewImage, fileInputRef, handleImageUpload, handleProfileImageClick, validateField } = useEditProfile({
     defaultProfileImage: profileImage,
   });
+
+  const [nicknameError, setNicknameError] = useState<string | undefined>();
+  const [bioError, setBioError] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (!isEditMode) {
+      setNicknameError(undefined);
+      setBioError(undefined);
+    }
+  }, [isEditMode]);
+
+  const handleNicknameChange = (value: string) => {
+    onNicknameChange?.(value);
+    const error = validateField('nickname', value);
+    setNicknameError(error);
+  };
+
+  const handleBioChange = (value: string) => {
+    onBioChange?.(value);
+    const error = validateField('bio', value);
+    setBioError(error);
+  };
 
   return (
     <>
@@ -55,25 +78,29 @@ const MyPageHeader = ({
         <div className={STYLES.profileEditFields}>
           <TextField
             value={nickname}
-            onChange={e => onNicknameChange?.(e.target.value)}
+            onChange={e => handleNicknameChange(e.target.value)}
             placeholder={MYPAGE_TEXTS.PROFILE.NICKNAME_PLACEHOLDER}
             fullWidth
             fontSize="medium"
             textColor="title"
             disabled={!isEditMode}
+            error={Boolean(nicknameError)}
+            errorMessage={nicknameError}
           />
           <div className={STYLES.textFieldDivider}>
             <span className={STYLES.hintText}>{MYPAGE_TEXTS.PROFILE.NICKNAME_HINT}</span>
           </div>
           <TextField
             value={bio}
-            onChange={e => onBioChange?.(e.target.value)}
+            onChange={e => handleBioChange(e.target.value)}
             placeholder={MYPAGE_TEXTS.PROFILE.BIO_PLACEHOLDER}
             fullWidth
             fontSize="light"
             textColor="gray78"
             className="mb-3 mt-3"
             disabled={!isEditMode}
+            error={Boolean(bioError)}
+            errorMessage={bioError}
           />
         </div>
       ) : (

--- a/src/constants/auth.constants.ts
+++ b/src/constants/auth.constants.ts
@@ -13,4 +13,8 @@ export const AUTH_TEXTS = {
       SNS: 'SNS',
     },
   },
+  SIGNUP: {
+    IMAGE_UPLOADED: '이미지가 업로드되었습니다.',
+    SIGNUP_FAILED: '회원가입을 할 수 없습니다.',
+  },
 } as const;

--- a/src/constants/image.constants.ts
+++ b/src/constants/image.constants.ts
@@ -1,0 +1,12 @@
+export const IMAGE_UPLOAD = {
+  MAX_SIZE: 5 * 1024 * 1024, // 5MB
+  ALLOWED_TYPES: ['image/'],
+} as const;
+
+export const IMAGE_TEXTS = {
+  UPLOAD: {
+    INVALID_TYPE: '이미지 파일만 선택해주세요.',
+    SIZE_EXCEEDED: '이미지 크기는 5MB 이하여야 합니다.',
+    FAILED: '이미지 업로드에 실패했습니다.',
+  },
+} as const;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,3 +4,4 @@ export * from './mypage.constants';
 export * from './blog.constants';
 export * from './pageheader.constants';
 export * from './oauth.constants';
+export * from './image.constants';

--- a/src/constants/mypage.constants.ts
+++ b/src/constants/mypage.constants.ts
@@ -32,6 +32,9 @@ export const MYPAGE_TEXTS = {
     BIO_PLACEHOLDER: '한줄 소개',
     NICKNAME_HINT: '*20글자 이내',
     SAVE_SUCCESS: '저장했습니다!',
+    NO_USER_INFO: '유저 정보가 없습니다.',
+    NO_CHANGES: '변경된 내용이 없습니다.',
+    UPDATE_FAILED: '프로필 업데이트에 실패했습니다.',
   },
 } as const;
 

--- a/src/constants/mypage.constants.ts
+++ b/src/constants/mypage.constants.ts
@@ -59,5 +59,5 @@ export const SIGNUP_FORM_FIELDS = [
   { name: 'name', title: '이름', type: undefined, placeholder: '이름', hintText: undefined },
   { name: 'birthDate', title: '생년월일', type: undefined, placeholder: 'YYYY-MM-DD', hintText: undefined },
   { name: 'nickname', title: '닉네임', type: undefined, placeholder: '닉네임', hintText: '20글자 이내' },
-  { name: 'bio', title: '한 줄 소개', type: undefined, placeholder: '한 줄 소개', hintText: undefined },
+  { name: 'introduction', title: '한 줄 소개', type: undefined, placeholder: '한 줄 소개', hintText: undefined },
 ] as const;

--- a/src/hooks/common/useS3ImageUpload.ts
+++ b/src/hooks/common/useS3ImageUpload.ts
@@ -1,0 +1,55 @@
+import { useUploadImageMutation } from '@/api/image/imageQuery';
+import { useToast } from '@/contexts/ToastContext';
+
+interface UseImageUploadOptions {
+  onSuccess?: (imageUrl: string) => void | Promise<void>;
+  onError?: (error: unknown) => void;
+}
+
+export const useS3ImageUpload = (options?: UseImageUploadOptions) => {
+  const uploadImageMutation = useUploadImageMutation();
+  const { showToast } = useToast();
+
+  const uploadImage = async (file: File): Promise<string | null> => {
+    try {
+      // 이미지 파일 검증
+      if (!file.type.startsWith('image/')) {
+        showToast('이미지 파일만 선택해주세요.', 'warning');
+        return null;
+      }
+
+      // 파일 크기 제한 (5MB)
+      const maxSize = 5 * 1024 * 1024;
+      if (file.size > maxSize) {
+        showToast('이미지 크기는 5MB 이하여야 합니다.', 'warning');
+        return null;
+      }
+
+      // S3 업로드
+      const result = await uploadImageMutation.mutateAsync({ file });
+      const imageUrl = result.imageUrl;
+
+      // 성공 콜백
+      if (options?.onSuccess) {
+        await options.onSuccess(imageUrl);
+      }
+
+      return imageUrl;
+    } catch (error) {
+      console.error('이미지 업로드 실패:', error);
+      showToast('이미지 업로드에 실패했습니다.', 'warning');
+
+      // 에러 콜백
+      if (options?.onError) {
+        options.onError(error);
+      }
+
+      return null;
+    }
+  };
+
+  return {
+    uploadImage,
+    isUploading: uploadImageMutation.isPending,
+  };
+};

--- a/src/hooks/common/useS3ImageUpload.ts
+++ b/src/hooks/common/useS3ImageUpload.ts
@@ -1,5 +1,6 @@
 import { useUploadImageMutation } from '@/api/image/imageQuery';
 import { useToast } from '@/contexts/ToastContext';
+import { IMAGE_UPLOAD, IMAGE_TEXTS } from '@/constants';
 
 interface UseImageUploadOptions {
   onSuccess?: (imageUrl: string) => void | Promise<void>;
@@ -13,15 +14,14 @@ export const useS3ImageUpload = (options?: UseImageUploadOptions) => {
   const uploadImage = async (file: File): Promise<string | null> => {
     try {
       // 이미지 파일 검증
-      if (!file.type.startsWith('image/')) {
-        showToast('이미지 파일만 선택해주세요.', 'warning');
+      if (!file.type.startsWith(IMAGE_UPLOAD.ALLOWED_TYPES[0])) {
+        showToast(IMAGE_TEXTS.UPLOAD.INVALID_TYPE, 'warning');
         return null;
       }
 
-      // 파일 크기 제한 (5MB)
-      const maxSize = 5 * 1024 * 1024;
-      if (file.size > maxSize) {
-        showToast('이미지 크기는 5MB 이하여야 합니다.', 'warning');
+      // 파일 크기 제한
+      if (file.size > IMAGE_UPLOAD.MAX_SIZE) {
+        showToast(IMAGE_TEXTS.UPLOAD.SIZE_EXCEEDED, 'warning');
         return null;
       }
 
@@ -37,13 +37,12 @@ export const useS3ImageUpload = (options?: UseImageUploadOptions) => {
       return imageUrl;
     } catch (error) {
       console.error('이미지 업로드 실패:', error);
-      showToast('이미지 업로드에 실패했습니다.', 'warning');
+      showToast(IMAGE_TEXTS.UPLOAD.FAILED, 'warning');
 
       // 에러 콜백
       if (options?.onError) {
         options.onError(error);
       }
-
       return null;
     }
   };

--- a/src/hooks/form/useKakaoCallback.ts
+++ b/src/hooks/form/useKakaoCallback.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useKakaoCallbackMutation } from '@/api/auth/authQuery';
 import { setAccessToken, setRefreshToken } from '@/api/apiInstance';
+import { useAuthStore } from '@/stores/useAuthStore';
 import { KAKAO_RESPONSE_CODE, KAKAO_REDIRECT_PATH } from '@/constants';
 import type { ApiResponse } from '@/api/apiTypes';
 import type { KakaoCallbackData } from '@/api/auth/authTypes';
@@ -20,6 +21,7 @@ const saveNewUserSession = (kakaoId?: number) => {
 export const useKakaoCallback = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const setIsKakaoUser = useAuthStore(state => state.setIsKakaoUser);
   const hasCalledRef = useRef(false);
 
   // 기존 회원
@@ -27,10 +29,11 @@ export const useKakaoCallback = () => {
     async (data: KakaoCallbackData) => {
       setAccessToken(data.accessToken || null);
       setRefreshToken(data.refreshToken || null);
+      setIsKakaoUser(true); // 카카오 사용자로 설정
       await queryClient.invalidateQueries({ queryKey: ['userInfo'] });
       navigate(KAKAO_REDIRECT_PATH.HOME, { replace: true });
     },
-    [queryClient, navigate]
+    [queryClient, navigate, setIsKakaoUser]
   );
 
   // 신규 회원

--- a/src/hooks/form/useSignup.ts
+++ b/src/hooks/form/useSignup.ts
@@ -9,6 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { useToast } from '@/contexts/ToastContext';
 import { setAccessToken, setRefreshToken } from '@/api/apiInstance';
 import { useAuthStore } from '@/stores/useAuthStore';
+import { AUTH_TEXTS } from '@/constants';
 
 interface UseSignupReturn {
   previewImage: string;
@@ -68,7 +69,7 @@ export const useSignup = (defaultImage: string): UseSignupReturn => {
     const imageUrl = await uploadImage(file);
     if (imageUrl) {
       setUploadedImageUrl(imageUrl);
-      showToast('이미지가 업로드되었습니다.', 'positive');
+      showToast(AUTH_TEXTS.SIGNUP.IMAGE_UPLOADED, 'positive');
     }
   };
 
@@ -103,7 +104,7 @@ export const useSignup = (defaultImage: string): UseSignupReturn => {
             navigate('/');
           },
           onError: () => {
-            showToast('회원가입을 할 수 없습니다.', 'warning');
+            showToast(AUTH_TEXTS.SIGNUP.SIGNUP_FAILED, 'warning');
           },
         }
       );
@@ -125,7 +126,7 @@ export const useSignup = (defaultImage: string): UseSignupReturn => {
             setIsCompleteModalOpen(true);
           },
           onError: () => {
-            showToast('회원가입을 할 수 없습니다.', 'warning');
+            showToast(AUTH_TEXTS.SIGNUP.SIGNUP_FAILED, 'warning');
           },
         }
       );

--- a/src/hooks/form/useSignup.ts
+++ b/src/hooks/form/useSignup.ts
@@ -7,6 +7,7 @@ import { useRegisterMutation, useRegisterOAuthMutation } from '@/api/auth/authQu
 import { useNavigate } from 'react-router-dom';
 import { useToast } from '@/contexts/ToastContext';
 import { setAccessToken, setRefreshToken } from '@/api/apiInstance';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 interface UseSignupReturn {
   previewImage: string;
@@ -38,6 +39,7 @@ export const useSignup = (defaultImage: string): UseSignupReturn => {
   const queryClient = useQueryClient();
   const registerMutation = useRegisterMutation();
   const registerOAuthMutation = useRegisterOAuthMutation();
+  const setIsKakaoUser = useAuthStore(state => state.setIsKakaoUser);
   const navigate = useNavigate();
   const { showToast } = useToast();
 
@@ -74,7 +76,7 @@ export const useSignup = (defaultImage: string): UseSignupReturn => {
           profilePicture: previewImage || '',
           birthDate: data.birthDate,
           name: data.name,
-          introduction: data.bio || '',
+          introduction: data.introduction || '',
           kakaoId: kakaoId,
         },
         {
@@ -83,6 +85,7 @@ export const useSignup = (defaultImage: string): UseSignupReturn => {
             sessionStorage.removeItem('kakaoId');
             setAccessToken(response.data.accessToken || null);
             setRefreshToken(response.data.refreshToken || null);
+            setIsKakaoUser(true); // 카카오 사용자로 설정
             await queryClient.invalidateQueries({ queryKey: ['userInfo'] });
             navigate('/');
           },
@@ -101,7 +104,7 @@ export const useSignup = (defaultImage: string): UseSignupReturn => {
           profilePicture: previewImage || '',
           birthDate: data.birthDate,
           name: data.name,
-          introduction: data.bio || '',
+          introduction: data.introduction || '',
         },
         {
           onSuccess: () => {

--- a/src/hooks/page/useEditProfile.ts
+++ b/src/hooks/page/useEditProfile.ts
@@ -1,67 +1,25 @@
-import { useEffect, useState, useRef, ChangeEvent } from 'react';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
+import { useState, useRef, ChangeEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { validators } from '@/utils/validation';
 import { useEditModeStore } from '@/stores/useEditModeStore';
 import { useToast } from '@/contexts/ToastContext';
+import * as UserQuery from '@/api/user/userQuery';
 import { MYPAGE_ROUTES, MYPAGE_TEXTS } from '@/constants';
-
-// 닉네임 & 한줄소개 검증 스키마
-const profileHeaderSchema = z.object({
-  nickname: validators.nickname(),
-  bio: validators.bio(),
-});
-
-type ProfileHeaderFormData = z.infer<typeof profileHeaderSchema>;
+import type { SignupFormData } from '@/utils/schemas';
 
 interface UseEditProfileProps {
-  nickname?: string;
-  bio?: string;
-  isEditMode?: boolean;
   defaultProfileImage?: string;
 }
 
-export const useEditProfile = ({
-  nickname = '',
-  bio = '',
-  isEditMode = false,
-  defaultProfileImage = '',
-}: UseEditProfileProps = {}) => {
+export const useEditProfile = ({ defaultProfileImage = '' }: UseEditProfileProps = {}) => {
   const { setEditMode } = useEditModeStore();
   const navigate = useNavigate();
   const { showToast } = useToast();
+  const { user } = UserQuery.useAuth();
+  const updateUser = UserQuery.useUpdateUser();
+  const updateNickname = UserQuery.useUpdateNickname();
+  const updatePassword = UserQuery.useUpdatePassword();
   const [previewImage, setPreviewImage] = useState<string>(defaultProfileImage);
   const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const {
-    register,
-    formState: { errors },
-    watch,
-    reset,
-  } = useForm<ProfileHeaderFormData>({
-    resolver: zodResolver(profileHeaderSchema),
-    mode: 'onChange',
-    defaultValues: {
-      nickname: nickname || '',
-      bio: bio || '',
-    },
-  });
-
-  // 현재 입력값을 watch로 가져오기
-  const watchedNickname = watch('nickname');
-  const watchedBio = watch('bio');
-
-  // 리셋
-  useEffect(() => {
-    if (!isEditMode) {
-      reset({
-        nickname: nickname || '',
-        bio: bio || '',
-      });
-    }
-  }, [isEditMode, nickname, bio, reset]);
 
   const handleEdit = () => {
     setEditMode(true);
@@ -71,11 +29,83 @@ export const useEditProfile = ({
     setEditMode(false);
   };
 
-  const handleSave = () => {
-    // TODO: API 호출로 프로필 업데이트
-    setEditMode(false);
-    showToast(MYPAGE_TEXTS.PROFILE.SAVE_SUCCESS, 'positive');
-    navigate(MYPAGE_ROUTES.MY_PROFILE);
+  const handleSave = (data: Partial<SignupFormData>) => {
+    if (!user) {
+      showToast('유저 정보가 없습니다.', 'warning');
+      return;
+    }
+
+    // 변경된 필드 감지
+    const fieldChecks = [
+      {
+        field: 'nickname',
+        hasChanged: () => data.nickname && data.nickname !== user.nickname,
+        value: data.nickname,
+      },
+      {
+        field: 'introduction',
+        hasChanged: () => data.introduction !== undefined && data.introduction !== user.introduction,
+        value: data.introduction,
+      },
+      {
+        field: 'password',
+        hasChanged: () => data.password && data.password !== '',
+        value: data.password,
+      },
+      {
+        field: 'birthDate',
+        hasChanged: () => data.birthDate && data.birthDate !== user.birthDate,
+        value: data.birthDate,
+      },
+    ];
+
+    const changes = fieldChecks
+      .filter(check => check.hasChanged())
+      .map(check => ({ field: check.field, value: check.value }));
+
+    if (changes.length === 0) {
+      showToast('변경된 내용이 없습니다.', 'warning');
+      return;
+    }
+
+    // 성공/실패 핸들러
+    const onSuccess = () => {
+      setEditMode(false);
+      showToast(MYPAGE_TEXTS.PROFILE.SAVE_SUCCESS, 'positive');
+      navigate(MYPAGE_ROUTES.MY_PROFILE);
+    };
+
+    const onError = () => {
+      showToast('프로필 업데이트에 실패했습니다.', 'warning');
+    };
+
+    // 1개 필드만 변경
+    if (changes.length === 1) {
+      const { field, value } = changes[0];
+
+      const apiMap: Record<string, () => void> = {
+        nickname: () => updateNickname.mutate({ nickname: value as string }, { onSuccess, onError }),
+        password: () => updatePassword.mutate({ password: value as string }, { onSuccess, onError }),
+      };
+
+      if (apiMap[field]) {
+        apiMap[field]();
+        return;
+      }
+    }
+
+    // 2개 이상 변경
+    const requestData = {
+      email: data.email || user.email,
+      nickname: data.nickname || user.nickname,
+      password: data.password || '',
+      profilePicture: user.profilePicture,
+      birthDate: data.birthDate || user.birthDate,
+      name: data.name || user.name,
+      introduction: data.introduction || '',
+    };
+
+    updateUser.mutate(requestData, { onSuccess, onError });
   };
 
   const handleImageUpload = (event: ChangeEvent<HTMLInputElement>) => {
@@ -94,11 +124,6 @@ export const useEditProfile = ({
   };
 
   return {
-    // 폼 관련
-    register,
-    errors,
-    watchedNickname,
-    watchedBio,
     // 이미지 관련
     previewImage,
     fileInputRef,

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -15,7 +15,7 @@ export default function Layout() {
   const isLoggedIn = useAuthStore(state => state.isLoggedIn);
 
   const pageHeaderType = usePageHeaderType();
-  const { handleEdit, handleCancel, handleSave } = useEditProfile();
+  const { handleEdit, handleCancel } = useEditProfile();
   const { id } = useParams();
   const location = useLocation();
 
@@ -38,7 +38,6 @@ export default function Layout() {
         onHamburgerClick={toggleSidebar}
         onEdit={handleEdit}
         onCancel={handleCancel}
-        onSave={handleSave}
         isOwner={isOwner}
       />
       <div ref={sidebarRef} className={`sidebar-container ${isSidebarOpen ? 'sidebar-open' : 'sidebar-closed'}`}>

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -1,8 +1,7 @@
-import { useState, useEffect } from 'react';
 import { cn } from '@/utils/cn';
 import { Outlet } from 'react-router-dom';
 import { Spacer, PostHeader, MyPageHeader } from '@/components';
-import { useMyPage } from '@/hooks';
+import { useMyPage, useEditProfile } from '@/hooks';
 
 interface MyPageProps {
   className?: string;
@@ -17,29 +16,10 @@ const STYLES = {
 } as const;
 
 const MyPage = ({ className }: MyPageProps) => {
-  const {
-    isMyProfile,
-    isEditProfile,
-    isProfilePage,
-    user,
-    isEditMode,
-    title,
-    subtitle,
-    spacerTopHeight,
-    handleEditProfile,
-  } = useMyPage();
+  const { isMyProfile, isEditProfile, isProfilePage, isEditMode, title, subtitle, spacerTopHeight, handleEditProfile } =
+    useMyPage();
 
-  // EditProfile 페이지에서 MyPageHeader와 EditProfileForm이 공유할 state
-  const [headerNickname, setHeaderNickname] = useState(user?.nickname || '');
-  const [headerIntroduction, setHeaderIntroduction] = useState(user?.introduction || '');
-
-  // user 정보가 변경되면 state 업데이트
-  useEffect(() => {
-    if (user) {
-      setHeaderNickname(user.nickname);
-      setHeaderIntroduction(user.introduction || '');
-    }
-  }, [user]);
+  const { headerNickname, headerIntroduction, setHeaderNickname, setHeaderIntroduction } = useEditProfile();
 
   return (
     <div className={STYLES.wrapper}>

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -2,6 +2,7 @@ import { cn } from '@/utils/cn';
 import { Outlet } from 'react-router-dom';
 import { Spacer, PostHeader, MyPageHeader } from '@/components';
 import { useMyPage, useEditProfile } from '@/hooks';
+import * as UserQuery from '@/api/user/userQuery';
 
 interface MyPageProps {
   className?: string;
@@ -19,7 +20,19 @@ const MyPage = ({ className }: MyPageProps) => {
   const { isMyProfile, isEditProfile, isProfilePage, isEditMode, title, subtitle, spacerTopHeight, handleEditProfile } =
     useMyPage();
 
-  const { headerNickname, headerIntroduction, setHeaderNickname, setHeaderIntroduction } = useEditProfile();
+  const { user } = UserQuery.useAuth();
+  const {
+    headerNickname,
+    headerIntroduction,
+    setHeaderNickname,
+    setHeaderIntroduction,
+    previewImage,
+    fileInputRef,
+    handleImageUpload,
+    handleProfileImageClick,
+    validateField,
+    handleSave,
+  } = useEditProfile({ defaultProfileImage: user?.profilePicture });
 
   return (
     <div className={STYLES.wrapper}>
@@ -30,18 +43,24 @@ const MyPage = ({ className }: MyPageProps) => {
             isEditMode={isEditProfile && isEditMode}
             nickname={headerNickname}
             bio={headerIntroduction}
+            profilePicture={user?.profilePicture}
             onNicknameChange={setHeaderNickname}
             onBioChange={setHeaderIntroduction}
             onEditClick={handleEditProfile}
             showSettingsButton={isMyProfile}
             isEditProfilePage={isEditProfile}
+            previewImage={previewImage}
+            fileInputRef={fileInputRef}
+            handleImageUpload={handleImageUpload}
+            handleProfileImageClick={handleProfileImageClick}
+            validateField={validateField}
           />
         ) : (
           <PostHeader title={title} subtitle={subtitle} className="w-full px-1" />
         )}
         <Spacer height="sm" className={STYLES.spacerBottom} />
       </div>
-      <Outlet context={{ headerNickname, headerIntroduction }} />
+      <Outlet context={{ headerNickname, headerIntroduction, handleSave }} />
     </div>
   );
 };

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -1,8 +1,8 @@
+import { useState, useEffect } from 'react';
 import { cn } from '@/utils/cn';
 import { Outlet } from 'react-router-dom';
 import { Spacer, PostHeader, MyPageHeader } from '@/components';
 import { useMyPage } from '@/hooks';
-import { MYPAGE_TEXTS } from '@/constants';
 
 interface MyPageProps {
   className?: string;
@@ -29,6 +29,18 @@ const MyPage = ({ className }: MyPageProps) => {
     handleEditProfile,
   } = useMyPage();
 
+  // EditProfile 페이지에서 MyPageHeader와 EditProfileForm이 공유할 state
+  const [headerNickname, setHeaderNickname] = useState(user?.nickname || '');
+  const [headerIntroduction, setHeaderIntroduction] = useState(user?.introduction || '');
+
+  // user 정보가 변경되면 state 업데이트
+  useEffect(() => {
+    if (user) {
+      setHeaderNickname(user.nickname);
+      setHeaderIntroduction(user.introduction || '');
+    }
+  }, [user]);
+
   return (
     <div className={STYLES.wrapper}>
       <div className={cn(STYLES.container, className)}>
@@ -36,8 +48,10 @@ const MyPage = ({ className }: MyPageProps) => {
         {isProfilePage ? (
           <MyPageHeader
             isEditMode={isEditProfile && isEditMode}
-            nickname={user?.nickname || MYPAGE_TEXTS.PROFILE.DEFAULT_USER_NAME}
-            bio={user?.introduction || MYPAGE_TEXTS.PROFILE.DEFAULT_BIO}
+            nickname={headerNickname}
+            bio={headerIntroduction}
+            onNicknameChange={setHeaderNickname}
+            onBioChange={setHeaderIntroduction}
             onEditClick={handleEditProfile}
             showSettingsButton={isMyProfile}
             isEditProfilePage={isEditProfile}
@@ -47,7 +61,7 @@ const MyPage = ({ className }: MyPageProps) => {
         )}
         <Spacer height="sm" className={STYLES.spacerBottom} />
       </div>
-      <Outlet />
+      <Outlet context={{ headerNickname, headerIntroduction }} />
     </div>
   );
 };

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -14,7 +14,7 @@ export const PrivateRoute = ({ children }: PrivateRouteProps) => {
   }
 
   if (!isLoggedIn) {
-    return <Navigate to="/mypage" replace />;
+    return <Navigate to="/" replace />;
   }
 
   return children;

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,24 +1,37 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 import { setAccessToken, setRefreshToken } from '@/api/apiInstance';
 
 interface AuthState {
   // UI 상태
   isLoggedIn: boolean;
+  isKakaoUser: boolean;
   setIsLoggedIn: (value: boolean) => void;
+  setIsKakaoUser: (value: boolean) => void;
   logout: () => void;
 }
 
-export const useAuthStore = create<AuthState>(set => ({
-  isLoggedIn: false,
+export const useAuthStore = create<AuthState>()(
+  persist(
+    set => ({
+      isLoggedIn: false,
+      isKakaoUser: false,
 
-  setIsLoggedIn: value => set({ isLoggedIn: value }),
+      setIsLoggedIn: value => set({ isLoggedIn: value }),
+      setIsKakaoUser: value => set({ isKakaoUser: value }),
 
-  logout: () => {
-    setAccessToken(null);
-    setRefreshToken(null);
-    sessionStorage.removeItem('isKakaoSignup');
-    sessionStorage.removeItem('kakaoId');
+      logout: () => {
+        setAccessToken(null);
+        setRefreshToken(null);
+        sessionStorage.removeItem('isKakaoSignup');
+        sessionStorage.removeItem('kakaoId');
 
-    set({ isLoggedIn: false }); // 로그아웃 시 컴포넌트 내에서 query캐시 삭제
-  },
-}));
+        set({ isLoggedIn: false, isKakaoUser: false }); // 로그아웃 시 초기화
+      },
+    }),
+    {
+      name: 'auth-storage',
+      storage: createJSONStorage(() => sessionStorage),
+    }
+  )
+);

--- a/src/types/mypage.ts
+++ b/src/types/mypage.ts
@@ -15,6 +15,8 @@ export type MyPageHeaderProps = ComponentWithBase<{
   isEditMode: boolean;
   nickname: string;
   bio: string;
+  onNicknameChange?: (nickname: string) => void;
+  onBioChange?: (bio: string) => void;
   onEditClick: () => void;
   showSettingsButton?: boolean;
   isEditProfilePage?: boolean;

--- a/src/types/mypage.ts
+++ b/src/types/mypage.ts
@@ -15,11 +15,17 @@ export type MyPageHeaderProps = ComponentWithBase<{
   isEditMode: boolean;
   nickname: string;
   bio: string;
+  profilePicture?: string;
   onNicknameChange?: (nickname: string) => void;
   onBioChange?: (bio: string) => void;
   onEditClick: () => void;
   showSettingsButton?: boolean;
   isEditProfilePage?: boolean;
+  previewImage?: string;
+  fileInputRef?: React.RefObject<HTMLInputElement>;
+  handleImageUpload?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleProfileImageClick?: () => void;
+  validateField?: (fieldName: 'nickname' | 'bio', value: string) => string | undefined;
 }>;
 
 export type MyPageFormProps = ComponentWithChildren;

--- a/src/types/pageheader.ts
+++ b/src/types/pageheader.ts
@@ -7,7 +7,6 @@ export type PageHeaderType = 'main' | 'detail' | 'write' | 'mypage' | 'editprofi
 export interface HeaderActionProps {
   onEdit?: () => void;
   onCancel?: () => void;
-  onSave?: () => void;
 }
 
 // 제네릭 타입

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,7 @@
+export * from './cn';
+export * from './blogContentParser';
+export * from './date';
+export * from './textFormatter';
+export * from './validation';
+export * from './schemas';
+export * from './profileHelpers';

--- a/src/utils/profileHelpers.ts
+++ b/src/utils/profileHelpers.ts
@@ -1,0 +1,72 @@
+import type { SignupFormData } from '@/utils/schemas';
+
+interface User {
+  email: string;
+  nickname: string;
+  profilePicture: string;
+  birthDate: string;
+  name: string;
+  introduction?: string;
+}
+
+interface ProfileChange {
+  field: string;
+  value: string | undefined;
+}
+
+export const detectProfileChanges = (data: Partial<SignupFormData>, user: User): ProfileChange[] => {
+  const fieldChecks = [
+    {
+      field: 'nickname',
+      hasChanged: () => data.nickname && data.nickname !== user.nickname,
+      value: data.nickname,
+    },
+    {
+      field: 'introduction',
+      hasChanged: () => data.introduction !== undefined && data.introduction !== user.introduction,
+      value: data.introduction,
+    },
+    {
+      field: 'password',
+      hasChanged: () => data.password && data.password !== '',
+      value: data.password,
+    },
+    {
+      field: 'birthDate',
+      hasChanged: () => data.birthDate && data.birthDate !== user.birthDate,
+      value: data.birthDate,
+    },
+  ];
+
+  return fieldChecks.filter(check => check.hasChanged()).map(check => ({ field: check.field, value: check.value }));
+};
+
+export const getUpdateStrategy = (
+  changes: ProfileChange[]
+): { type: 'single' | 'multiple' | 'none'; field?: string; value?: string } => {
+  if (changes.length === 0) {
+    return { type: 'none' };
+  }
+
+  if (changes.length === 1) {
+    const { field, value } = changes[0];
+    // nickname과 password만 단일 API 호출 가능
+    if (field === 'nickname' || field === 'password') {
+      return { type: 'single', field, value };
+    }
+  }
+
+  return { type: 'multiple' };
+};
+
+export const buildUpdateRequest = (data: Partial<SignupFormData>, user: User) => {
+  return {
+    email: data.email || user.email,
+    nickname: data.nickname || user.nickname,
+    password: data.password || '',
+    profilePicture: user.profilePicture,
+    birthDate: data.birthDate || user.birthDate,
+    name: data.name || user.name,
+    introduction: data.introduction || '',
+  };
+};

--- a/src/utils/profileHelpers.ts
+++ b/src/utils/profileHelpers.ts
@@ -27,11 +27,6 @@ export const detectProfileChanges = (data: Partial<SignupFormData>, user: User):
       value: data.introduction,
     },
     {
-      field: 'password',
-      hasChanged: () => data.password && data.password !== '',
-      value: data.password,
-    },
-    {
       field: 'birthDate',
       hasChanged: () => data.birthDate && data.birthDate !== user.birthDate,
       value: data.birthDate,
@@ -50,8 +45,7 @@ export const getUpdateStrategy = (
 
   if (changes.length === 1) {
     const { field, value } = changes[0];
-    // nickname과 password만 단일 API 호출 가능
-    if (field === 'nickname' || field === 'password') {
+    if (field === 'nickname') {
       return { type: 'single', field, value };
     }
   }
@@ -63,7 +57,6 @@ export const buildUpdateRequest = (data: Partial<SignupFormData>, user: User) =>
   return {
     email: data.email || user.email,
     nickname: data.nickname || user.nickname,
-    password: data.password || '',
     profilePicture: user.profilePicture,
     birthDate: data.birthDate || user.birthDate,
     name: data.name || user.name,

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -17,4 +17,11 @@ export const signupSchema = zod
     path: ['passwordConfirm'],
   });
 
+// 프로필 수정 스키마
+export const profileEditSchema = signupSchema.omit({
+  password: true,
+  passwordConfirm: true,
+});
+
 export type SignupFormData = zod.infer<typeof signupSchema>;
+export type ProfileEditFormData = zod.infer<typeof profileEditSchema>;

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -10,7 +10,7 @@ export const signupSchema = zod
     name: validators.name(),
     birthDate: validators.birthDate(),
     nickname: validators.nickname(),
-    bio: validators.bio(),
+    introduction: validators.bio(),
   })
   .refine(data => data.password === data.passwordConfirm, {
     message: VALIDATION_MESSAGES.passwordConfirm.mismatch,


### PR DESCRIPTION
## ✨ 주요 변경사항

- 프로필 편집 기능 개선 및 검증 로직 추가
- 변경 감지 로직 선언적 방식으로 리팩토링
- 상태 관리 구조 개선 (Outlet context 활용)
- 카카오 로그인 사용자 프로필 편집 지원
- User API 연결 및 특화 API 엔드포인트 활용

---

## 📝 작업 상세 내용

### 1. 프로필 편집 기능 개선

- **MyPageHeader 닉네임/자기소개 필드 검증 추가**
  - 실시간 필드 검증 기능 구현 (`validateField` 함수)
  - 닉네임: 영문/숫자만 허용, 2-20자 제한
  - 자기소개: 최대 100자 제한
  - 에러 메시지 실시간 표시

- **변경 감지 로직 리팩토링**
  - 선언적 방식의 `fieldChecks` 배열로 변경 감지 로직 개선
  - 1개 필드만 변경 시 특화 API 사용:
    - `nickname` → `/users/nickname` API
    - `password` → `/users/password` API
  - 2개 이상 필드 변경 시 `/users` API 사용
  - if-else 체인 제거하여 가독성 향상

### 1. 프로필 편집 기능 개선

- **MyPageHeader 닉네임/자기소개 필드 검증 추가**
  - 실시간 필드 검증 기능 구현 (`validateField` 함수)
  - 닉네임: 영문/숫자만 허용, 2-20자 제한
  - 자기소개: 최대 100자 제한
  - 에러 메시지 실시간 표시

- **변경 감지 로직 리팩토링**
  - 선언적 방식의 `fieldChecks` 배열로 변경 감지 로직 개선
  - 1개 필드만 변경 시 특화 API 사용 (`nickname` → `/users/nickname`, `password` → `/users/password`)
  - 2개 이상 필드 변경 시 `/users` API 사용
  - if-else 체인 제거하여 가독성 향상

### 2. 상태 관리 구조 개선

- EditProfileForm을 Outlet context 기반으로 변경하여 컴포넌트 간 상태 공유 개선
- MyPage 상태 관리를 Context에서 useState로 변경하여 구조 단순화
- 헤더 필드 상태 관리를 `useEditProfile` 훅으로 통합 관리

### 3. 카카오 로그인 사용자 지원

- 카카오 사용자 프로필 편집 시 비밀번호 필드 숨김 처리
- 카카오 소셜 로그인 표시 추가
- `isKakaoUser` 상태에 따른 필드 제외 로직 구현

### 4. User API 연결

- User API 엔드포인트 연결 (`updateUser`, `updateNickname`, `updatePassword`, `updateProfilePicture`)

### 5. Layout 및 PageHeader 개선

- Layout에서 EditProfile 핸들러를 `useEditProfile` 훅으로 통합
- PageHeader에 EditProfile 타입 및 `onEdit`, `onCancel` 액션 추가

---

## ✅ 체크리스트

- [x] GitHub 이슈에 `resolves: #번호`를 추가했는가?
- [x] 불필요한 주석, 디버깅 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작 확인했는가?

---

## 📸 스크린샷 (선택)
<img width="1919" height="1018" alt="image" src="https://github.com/user-attachments/assets/cb7976e3-cf22-45c9-97de-c3a07f3225a4" />
<img width="1919" height="1017" alt="image" src="https://github.com/user-attachments/assets/28d04edd-c485-4de8-a409-5070886845d9" />

<br>

자체 로그인 회원정보 수정

<img width="1919" height="1013" alt="image" src="https://github.com/user-attachments/assets/59c463cb-ee9a-4775-bea0-0789ba4d2685" />
<img width="1919" height="1018" alt="image" src="https://github.com/user-attachments/assets/1cb0dbaf-ffd1-4cfa-bd78-370bfd118cc7" />
<img width="1919" height="1013" alt="image" src="https://github.com/user-attachments/assets/9dad1006-8931-4f02-8960-9ab402fefa2f" />

<br>

카카오 로그인 회원정보 수정(프로필 이미지)

---

## 🔍 기타 참고사항

- 이번주는 너무 바빠서 많이 못했습니다 ㅠㅠ
- 부랴부랴 만드느라고 코드가 엉망진창입니다. 리뷰 달게 받겠습니다...
- 아직 구현할 부분이 산더미입니다 ㅠㅠ

#### 추후 개선 필요 사항

- 프로필 사진 업로드 기능 연동
- 에러 바운더리 추가
- 로딩/에러 상태에 대한 전역 처리

---

## 🔗 관련 이슈

- Close #56 